### PR TITLE
Fix incomplete webp conversion for srcset

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -703,7 +703,7 @@ final class Cache_Enabler_Disk {
      */
 
     private static function _convert_webp_srcset($srcset) {
-
+        $srcset = preg_replace('/(\s\s+|\t|\n)/', ' ', $srcset);
         $sizes = explode(', ', $srcset);
         $upload_dir = wp_upload_dir();
         $src_url = parse_url($upload_dir['baseurl']);


### PR DESCRIPTION
If whitespaces other than a single space (e.g. newline) is used to separate image srcset, the method fails. So remove all white spaces before exploding.